### PR TITLE
Add C++14 standard to avoid error on newer version of GCC

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ def get_config():
     incs.append(get_python_inc())
     incs.extend(blas_info().get_include_dirs())
 
-    cc_flags = ['-fPIC', '-m64']
+    cc_flags = ['--std=c++14', '-fPIC', '-m64']
 
     for _ in np.__config__.blas_opt_info.get('extra_compile_args', []):
         if _ not in cc_flags:


### PR DESCRIPTION
Avoid " error: ISO C++17 does not allow dynamic exception specifications" errors when compiling.

When compiling with  GCC 11.3.0, SWIG wrapper  sources throw errors about C++17
I added a flag to force C++14 standard during compilation.